### PR TITLE
v1.4: plugin_dir_url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "unity-carousels",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "unity-carousels",
-			"version": "1.3.0",
+			"version": "1.4.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@glidejs/glide": "^3.6.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "unity-carousels",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"description": "glidejs carousel customized for UDS",
 	"author": "ASU KE Web Services",
 	"license": "GPL-2.0-or-later",

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
  - Contributors:      ASU KE Web Services
  - Tested up to:      6.7.1
- - Stable tag:        v1.3.0
+ - Stable tag:        v1.4.0
  - License:           GPL-2.0-or-later
  - License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -56,6 +56,8 @@ When an update for `component-carousel` from UDS is released, a developer can up
 - build latest
 
 ## Changelog
+### 1.4.0
+- `plugin_dir_url(__FILE__) .`
 ### 1.3.0
 - component-carousel v2.4.0
 ### 1.2.0

--- a/unity-carousels.php
+++ b/unity-carousels.php
@@ -4,7 +4,7 @@
  * Description:       Carousels built with glidejs customized for UDS.
  * Requires at least: 6.2.0
  * Requires PHP:      7.4
- * Version:           1.3.0
+ * Version:           1.4.0
  * Author:            ASU KE Web Services
  * Author URI:        https://rto.asu.edu/web-services
  * License:           GPL-2.0-or-later
@@ -48,7 +48,7 @@ function unitycarousels_register_block_category($categories)
 add_filter('block_categories_all', 'unitycarousels_register_block_category');
 
 function unity_carousels_scripts() {
-	wp_enqueue_script( 'unity-carousels-glidejs', '/wp-content/plugins/unity-carousels/resources/glidejs/glide.min.js', array(), '3.6.2', true );
-	wp_enqueue_style('unity-carousels-glidejs-style', '/wp-content/plugins/unity-carousels/resources/glidejs/glide.core.min.css', array(), '3.6.2', 'all');
+	wp_enqueue_script( 'unity-carousels-glidejs', plugin_dir_url(__FILE__) . 'resources/glidejs/glide.min.js', array(), '3.6.2', true );
+	wp_enqueue_style('unity-carousels-glidejs-style', plugin_dir_url(__FILE__) . 'resources/glidejs/glide.core.min.css', array(), '3.6.2', 'all');
 }
 add_action( 'wp_enqueue_scripts', 'unity_carousels_scripts' );


### PR DESCRIPTION
WP Engine can't see absolute paths for plugins, update to use `plugin_dir_url` 